### PR TITLE
fix: Исправление ошибок, удаление ненужного кода.

### DIFF
--- a/resources/views/fields/fileManager.blade.php
+++ b/resources/views/fields/fileManager.blade.php
@@ -24,7 +24,6 @@
 
         @php($raw = is_iterable($value) ? $value : [$value])
         @php($files = $element->getFullPathValues())
-
         @if(is_array($files) ? array_filter($files) : $files->isNotEmpty())
             <div class="dropzone">
                 <div class="dropzone-items"
@@ -86,21 +85,28 @@
 
     let lfmInput{{ $uniqueID }} = document.querySelector('.lfm-input__{{ $uniqueID }}');
 
+    const getPath = (el) => {
+        if(el.nextElementSibling && el.nextElementSibling.hasAttribute('src')) {
+            return el.nextElementSibling.getAttribute('src')
+        } else if(el.previousElementSibling && el.previousElementSibling.querySelector('a')) {
+            return el.previousElementSibling.querySelector('a').getAttribute('href')
+        }
+        return null
+    }
     document.querySelectorAll('.lfm__{{ $uniqueID }} + * button').forEach((button) => {
 
         button.addEventListener('click', function () {
-            let image = button.nextElementSibling.getAttribute('src');
+            let path = getPath(button);
 
             let values = lfmInput{{ $uniqueID }}.value.split(',');
 
-            if (values.includes(image)) {
+            if (values.includes(path)) {
                 values = values.filter(function (value) {
-                    return value !== image;
+                    return value !== path;
                 });
             } else {
-                values.push(image);
+                values.push(path);
             }
-
             lfmInput{{ $uniqueID }}.value = values.join(',');
         });
     });

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -55,7 +55,6 @@ class FileManager extends File
         if (is_string($file)) {
             $initPath = str_replace(config('app.url') . '/storage/', '', $file);
             $path = Storage::disk('public')->path($initPath);
-
             if (!file_exists($path)) {
                 Log::error("File not found: $path");
                 throw new FieldException("File not found: $path");
@@ -80,18 +79,6 @@ class FileManager extends File
     {
         return function ($item) {
             $requestValue = $this->requestValue();
-
-            if (
-                $requestValue
-                && !$this->isMultiple()
-                && $this->isDeleteFiles()
-                && $requestValue->hashName()
-            ) {
-                $this->checkAndDelete(
-                    request()->input($this->hiddenOldValuesKey()),
-                    $requestValue->hashName()
-                );
-            }
 
             $oldValues = request()
                 ->collect($this->hiddenOldValuesKey());
@@ -122,7 +109,6 @@ class FileManager extends File
                     $saveValue = $this->store($requestValue);
                 }
             }
-
             return data_set($item, $this->column(), $saveValue);
         };
     }


### PR DESCRIPTION
В FilaManager.php удалил:
```php
if (
    $requestValue
    && !$this->isMultiple()
    && $this->isDeleteFiles()
    && $requestValue->hashName()
) {
   $this->checkAndDelete(
       request()->input($this->hiddenOldValuesKey()),
       $requestValue->hashName()
   );
}
```
так как `$this->isMultiple()` всегда `true`
При работе с не изображениями удаление не работало из-за того что поиск пути к файлу осуществлялся в следующем элементе, а при работе с файлами не изображений они находятся перед кнопкой удаления.